### PR TITLE
Use os.execv in wrapper script instead of subprocess

### DIFF
--- a/pypatchelf/__init__.py
+++ b/pypatchelf/__init__.py
@@ -1,9 +1,8 @@
 import sys
-import os.path
-import subprocess
+import os
 
 PATCHELF = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'patchelf')
 
 
 def main():
-    subprocess.check_output([PATCHELF] + sys.argv[1:])
+    os.execv(PATCHELF, sys.argv)


### PR DESCRIPTION
This fixes things like `patchelf --version`, since check_output
was capturing the output, and also makes sure that `patchelf` with
no arguments doesn't print a Python traceback.
